### PR TITLE
#43 記事一覧を取得するAPIを実装

### DIFF
--- a/api/article/v1/article.proto
+++ b/api/article/v1/article.proto
@@ -31,10 +31,12 @@ message ShareResponse {}
 
 // 一覧リクエスト
 message ListRequest {
-  uint32 page = 1;
+  string page_token = 1;
+  uint32 max_page_size = 2;
 }
 
 // 一覧レスポンス
 message ListResponse {
   repeated Article articles = 1;
+  string next_page_token = 2;
 }

--- a/api/article/v1/article.proto
+++ b/api/article/v1/article.proto
@@ -4,13 +4,37 @@ package article.v1;
 
 option go_package = "github.com/morning-night-guild/platform/pkg/connect/article/v1;articlev1";
 
+// 記事サービス
+service ArticleService {
+  // Need X-API-KEY Header
+  rpc Share(ShareRequest) returns (ShareResponse) {}
+  rpc List(ListRequest) returns (ListResponse) {}
+}
+
+// 記事モデル
+message Article {
+  string id = 1;
+  string title = 2;
+  string url = 3;
+  string description = 4;
+  string thumbnail = 5;
+  repeated string tags = 6;
+}
+
+// 共有リクエスト
 message ShareRequest {
   string url = 1;
 }
 
+// 共有レスポンス
 message ShareResponse {}
 
-service ArticleService {
-  // Need X-API-KEY Header
-  rpc Share(ShareRequest) returns (ShareResponse) {}
+// 一覧リクエスト
+message ListRequest {
+  uint32 page = 1;
+}
+
+// 一覧レスポンス
+message ListResponse {
+  repeated Article articles = 1;
 }

--- a/backend/app/core/adapter/controller/article.go
+++ b/backend/app/core/adapter/controller/article.go
@@ -55,7 +55,7 @@ func (a Article) List(
 	ctx context.Context,
 	req *connect.Request[articlev1.ListRequest],
 ) (*connect.Response[articlev1.ListResponse], error) {
-	size := 2
+	size := int(req.Msg.MaxPageSize)
 
 	articles := make([]*articlev1.Article, 0, size)
 
@@ -71,7 +71,8 @@ func (a Article) List(
 	}
 
 	res := connect.NewResponse(&articlev1.ListResponse{
-		Articles: articles,
+		Articles:      articles,
+		NextPageToken: "",
 	})
 
 	return res, nil

--- a/backend/app/core/adapter/controller/article.go
+++ b/backend/app/core/adapter/controller/article.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"os"
+	"strconv"
 
 	"github.com/bufbuild/connect-go"
 	"github.com/morning-night-guild/platform/app/core/model/article"
@@ -47,4 +48,31 @@ func (a Article) Share(
 	}
 
 	return connect.NewResponse(&articlev1.ShareResponse{}), nil
+}
+
+// List 記事を取得するコントローラメソッド.
+func (a Article) List(
+	ctx context.Context,
+	req *connect.Request[articlev1.ListRequest],
+) (*connect.Response[articlev1.ListResponse], error) {
+	size := 2
+
+	articles := make([]*articlev1.Article, 0, size)
+
+	for i := 0; i < size; i++ {
+		articles = append(articles, &articlev1.Article{
+			Id:          strconv.Itoa(i),
+			Title:       "example",
+			Url:         "https://example.com",
+			Description: "example description",
+			Thumbnail:   "",
+			Tags:        []string{"Go"},
+		})
+	}
+
+	res := connect.NewResponse(&articlev1.ListResponse{
+		Articles: articles,
+	})
+
+	return res, nil
 }


### PR DESCRIPTION
@Shitomo 

記事一覧を取得するprotoを定義しました。
命名は[こちら](https://github.com/mercari/mercari-microservices-example/blob/main/services/item/proto/item.proto)を参考にしています。
コントローラー層は仮実装です。

- 記事共有日時（作成日時）の降順で取得

を想定しています。