### PR TITLE
chore(#103) リポジトリ名を補足

### DIFF
--- a/backend/app/core/cloudbuild.yaml
+++ b/backend/app/core/cloudbuild.yaml
@@ -40,7 +40,7 @@ steps:
     dir: "backend"
   - name: "gcr.io/$PROJECT_ID/platform-deployer"
     env:
-      - "KO_DOCKER_REPO=gcr.io/$PROJECT_ID"
+      - "KO_DOCKER_REPO=gcr.io/$PROJECT_ID/core"
       - "REVISION_SERVICE_ACCOUNT=$_REVISION_SERVICE_ACCOUNT"
       - "API_KEY=${_API_KEY}:latest"
       - "DATABASE_URL=${_DATABASE_URL}:latest"

--- a/backend/app/slack/cloudbuild.yaml
+++ b/backend/app/slack/cloudbuild.yaml
@@ -34,7 +34,7 @@ steps:
     dir: "api"
   - name: "gcr.io/$PROJECT_ID/platform-deployer"
     env:
-      - "KO_DOCKER_REPO=gcr.io/$PROJECT_ID"
+      - "KO_DOCKER_REPO=gcr.io/$PROJECT_ID/slack"
       - "REVISION_SERVICE_ACCOUNT=$_REVISION_SERVICE_ACCOUNT"
       - "API_KEY=${_API_KEY}:latest"
     script: |


### PR DESCRIPTION
# 概要

--bareを指定することで、これまでkoが親ディレクトリから勝手に生成していたリポジトリ名を自分で指定する必要が出てきます。  

それらをKO_DOCKER_REPOに補足しました