### PR TITLE
#159 bufに関するインストールをaquaを利用するように修正

### DIFF
--- a/.github/workflows/api.lint.yml
+++ b/.github/workflows/api.lint.yml
@@ -13,10 +13,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up Buf
-        uses: bufbuild/buf-setup-action@v1
+      - name: Set up aqua
+        uses: aquaproj/aqua-installer@v1.1.2
         with:
-          version : 'latest'
+          aqua_version: v1.25.0
+
+      - name: Set up api go tool
+        working-directory: ./api
+        run: ${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin/aqua i
 
       - name: Buf lint
         working-directory: ./api

--- a/.github/workflows/api.lint.yml
+++ b/.github/workflows/api.lint.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: backend/go.mod
+
       - name: Set up aqua
         uses: aquaproj/aqua-installer@v1.1.2
         with:

--- a/.github/workflows/frontend.diff.yml
+++ b/.github/workflows/frontend.diff.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: backend/go.mod
+
       - name: Set up aqua
         uses: aquaproj/aqua-installer@v1.1.2
         with:

--- a/.github/workflows/frontend.diff.yml
+++ b/.github/workflows/frontend.diff.yml
@@ -13,15 +13,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up protoc
-        uses: arduino/setup-protoc@v1
+      - name: Set up aqua
+        uses: aquaproj/aqua-installer@v1.1.2
         with:
-          version: "v3.20.2"
-      
-      - name: Set up bufbulid
-        uses: bufbuild/buf-setup-action@v1
-        with:
-          version: "1.9.0"
+          aqua_version: v1.25.0
+
+      - name: Set up api go tool
+        working-directory: ./api
+        run: ${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin/aqua i
 
       - name: Generate
         working-directory: ./api


### PR DESCRIPTION
@Shitomo 

CIでもaquaを使ってtoolをインストールするように修正しました。
共通化するか微妙なところですが、
下手に共通化して修正がめんどくさくなるのを避けるため共通化はしないです。
