### PR TITLE
#161 |で連結されたURLが来た場合、最初のURLを取り出すよう修正

### DIFF
--- a/.github/workflows/supabase.test.yml
+++ b/.github/workflows/supabase.test.yml
@@ -7,7 +7,7 @@ on:
       - supabase/functions/*
 
 jobs:
-  deploy:
+  test:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/supabase.test.yml
+++ b/.github/workflows/supabase.test.yml
@@ -14,7 +14,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: denoland/setup-deno@v1
+      - name: Setup deno
+        uses: denoland/setup-deno@v1
         with:
           deno-version: "1.28.2"
 

--- a/.github/workflows/supabase.test.yml
+++ b/.github/workflows/supabase.test.yml
@@ -1,0 +1,24 @@
+name: supabase test
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/supabase.test.yml
+      - supabase/functions/*
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: "1.28.2"
+
+      - name: Test
+        # --allow-env: index.ts内で環境変数にアクセスする処理があるため許可しておく必要あり
+        # --allow-net: index.ts内でポートをリッスンする処理があるため許可しておく必要あり
+        run: deno test --allow-env --allow-net

--- a/supabase/functions/slack/index.test.ts
+++ b/supabase/functions/slack/index.test.ts
@@ -1,0 +1,24 @@
+import {
+    assertEquals,
+} from "https://deno.land/std@0.65.0/testing/asserts.ts";
+import { extractFirstUrlFromUrlsConcatByPipe } from "./index.ts"
+
+// extractFirstUrlFromUrlsConcatByPipe
+
+Deno.test("URLに|が含まれていない場合は引数をそのまま返す", () => {
+  const actual = extractFirstUrlFromUrlsConcatByPipe('http://example.com')
+  
+  assertEquals(actual, 'http://example.com');
+});
+
+Deno.test("URLに|が含まれている場合は、|で区切った最初の文字列を返す", () => {
+    const actual = extractFirstUrlFromUrlsConcatByPipe('http://example.com|http://example.com')
+    
+    assertEquals(actual, 'http://example.com');
+});
+
+Deno.test("URLが空文字の場合は空文字を返す", () => {
+    const actual = extractFirstUrlFromUrlsConcatByPipe('')
+    
+    assertEquals(actual, '');
+});

--- a/supabase/functions/slack/index.ts
+++ b/supabase/functions/slack/index.ts
@@ -33,7 +33,7 @@ export type Event = {
  * 
  *  https://github.com/morning-night-guild/platform/issues/161 の暫定対応
  */
-const extractFirstUrlFromUrlsConcatByPipe = (url : string) => {
+export const extractFirstUrlFromUrlsConcatByPipe = (url : string) => {
   if (!url?.includes('|')) {
     return url;
   }

--- a/supabase/functions/slack/index.ts
+++ b/supabase/functions/slack/index.ts
@@ -27,6 +27,21 @@ export type Event = {
   ts: number;
 };
 
+
+/**
+ * '|'によって連結されたURL達から、最初のURLを取り出す
+ * 
+ *  https://github.com/morning-night-guild/platform/issues/161 の暫定対応
+ */
+const extractFirstUrlFromUrlsConcatByPipe = (url : string) => {
+  if (!url?.includes('|')) {
+    return url;
+  }
+
+  const urls = url.split('|');
+  return urls[0];
+}
+
 const env: Env = {
   API_KEY: Deno.env.get("CORE_API_KEY") ?? "",
   CORE_SERVICE_URL: Deno.env.get("CORE_SERVICE_URL") ?? "",
@@ -47,8 +62,10 @@ export const callback = async (
   console.log(event.type);
   const pattern = /http(.*):\/\/([a-zA-Z0-9/\-\_\.]*)/;
   try {
-    const url = event.event.text.match(pattern)?.find((s) => s);
-    console.log(url);
+    const u = event.event.text.match(pattern)?.find((s) => s);
+    console.log(u);
+
+    const url = extractFirstUrlFromUrlsConcatByPipe(u ?? '');
 
     const init = {
       body: JSON.stringify({ url: url }),


### PR DESCRIPTION
暫定対応

`https://example.com|https://example.com`のような`|`で連結されたURLが来た場合、`|`で分割して最初のURLのみを取り出して`core`サービスに送信するよう修正しました