### PR TITLE
#285 testに関する実装がtesting.Tに依存するように修正

### DIFF
--- a/backend/internal/adapter/gateway/article_test.go
+++ b/backend/internal/adapter/gateway/article_test.go
@@ -31,14 +31,16 @@ func NewRDBClientMock(t *testing.T) *RDBClientMock {
 	}
 }
 
-func (r *RDBClientMock) Of(dsn string) (*gateway.RDB, error) {
+func (rm *RDBClientMock) Of(dsn string) (*gateway.RDB, error) {
+	rm.t.Helper()
+
 	opts := []enttest.Option{
-		enttest.WithOptions(ent.Log(r.t.Log)),
+		enttest.WithOptions(ent.Log(rm.t.Log)),
 	}
 
 	dataSourceName := fmt.Sprintf("file:%s?mode=memory&cache=shared&_fk=1", dsn)
 
-	db := enttest.Open(r.t, "sqlite3", dataSourceName, opts...)
+	db := enttest.Open(rm.t, "sqlite3", dataSourceName, opts...)
 
 	return &gateway.RDB{
 		Client: db,

--- a/backend/internal/adapter/mock/article.go
+++ b/backend/internal/adapter/mock/article.go
@@ -1,0 +1,46 @@
+package mock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/morning-night-guild/platform/internal/domain/model"
+	"github.com/morning-night-guild/platform/internal/domain/model/article"
+	"github.com/morning-night-guild/platform/internal/usecase/port"
+)
+
+type ShareUsecase struct {
+	T   *testing.T
+	Err error
+}
+
+const ID = "12345678-1234-1234-1234-1234567890ab"
+
+func (su ShareUsecase) Execute(ctx context.Context, input port.ShareArticleInput) (port.ShareArticleOutput, error) {
+	su.T.Helper()
+
+	return port.ShareArticleOutput{
+		Article: model.Article{
+			ID:          article.ID(uuid.MustParse(ID)),
+			URL:         input.URL,
+			Title:       input.Title,
+			Description: input.Description,
+			Thumbnail:   input.Thumbnail,
+		},
+	}, su.Err
+}
+
+type ListUsecase struct {
+	T        *testing.T
+	Articles []model.Article
+	Err      error
+}
+
+func (lu ListUsecase) Execute(ctx context.Context, input port.ListArticleInput) (port.ListArticleOutput, error) {
+	lu.T.Helper()
+
+	return port.ListArticleOutput{
+		Articles: lu.Articles,
+	}, lu.Err
+}

--- a/backend/internal/usecase/interactor/article/list_test.go
+++ b/backend/internal/usecase/interactor/article/list_test.go
@@ -39,6 +39,7 @@ func TestListInteractorExecute(t *testing.T) {
 			name: "記事一覧を取得できる",
 			fields: fields{
 				articleRepository: &mock.Article{
+					T: t,
 					Articles: []model.Article{
 						{
 							ID:          article.ID(id),

--- a/backend/internal/usecase/interactor/article/share_test.go
+++ b/backend/internal/usecase/interactor/article/share_test.go
@@ -37,6 +37,7 @@ func TestShareInteractorExecute(t *testing.T) {
 			name: "記事を共有できる",
 			fields: fields{
 				articleRepository: &mock.Article{
+					T:   t,
 					Err: nil,
 				},
 			},
@@ -64,6 +65,7 @@ func TestShareInteractorExecute(t *testing.T) {
 			name: "記事Repositoryのerrorを握りつぶさない",
 			fields: fields{
 				articleRepository: &mock.Article{
+					T:   t,
 					Err: errors.New("article repository error"),
 				},
 			},

--- a/backend/internal/usecase/mock/article.go
+++ b/backend/internal/usecase/mock/article.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+	"testing"
 
 	"github.com/morning-night-guild/platform/internal/domain/model"
 	"github.com/morning-night-guild/platform/internal/domain/repository"
@@ -11,12 +12,15 @@ var _ repository.Article = (*Article)(nil)
 
 // Article 記事リポジトリのモック.
 type Article struct {
+	T        *testing.T
 	Articles []model.Article
 	Err      error
 }
 
 // Save 記事を保存するモックメソッド.
 func (a *Article) Save(ctx context.Context, article model.Article) error {
+	a.T.Helper()
+
 	return a.Err
 }
 
@@ -26,5 +30,7 @@ func (a *Article) FindAll(
 	index repository.Index,
 	size repository.Size,
 ) ([]model.Article, error) {
+	a.T.Helper()
+
 	return a.Articles, a.Err
 }


### PR DESCRIPTION
@Shitomo 

testに関する実装が `testing.T` に依存するように修正しました。

目的は以下となります。

- 引数に `testing.T` があることでテストでしか利用できない
- 引数に `testing.T` があることでメソッドや構造体がテスト専用だと明記できる（命名に ForTest などを含める必要がなくなる）
