### PR TITLE
#302 記事一覧をread moreボタンで20ずつ取得するよう修正

### DIFF
--- a/frontend/src/page/Article/index.tsx
+++ b/frontend/src/page/Article/index.tsx
@@ -1,10 +1,10 @@
-import { Grid, GridItem, Center, Heading, Box } from '@chakra-ui/react';
+import { Grid, GridItem, Center, Heading, Box, Button } from '@chakra-ui/react';
 import { Header } from '../Header';
 import { useListArticles } from '../../swr/useApiArticle';
 import { ArticleCard } from './ArticleCard';
 
 export function Article() {
-    const data = useListArticles();
+    const { data, mutate } = useListArticles();
 
     return (
         <>
@@ -20,7 +20,7 @@ export function Article() {
                             gap={6}
                             templateColumns={['repeat(1, 1fr)', 'repeat(1, 1fr)', 'repeat(2, 1fr)', 'repeat(2, 1fr)']}
                         >
-                            {data?.articles?.map((article) => {
+                            {data.map((article) => {
                                 return (
                                     <GridItem key={article.id} colSpan={1}>
                                         <ArticleCard
@@ -33,6 +33,7 @@ export function Article() {
                             })}
                         </Grid>
                     </Center>
+                    <Button onClick={mutate}>Read More</Button>
                 </GridItem>
                 <GridItem colSpan={2} />
             </Grid>

--- a/frontend/src/swr/useApiArticle.ts
+++ b/frontend/src/swr/useApiArticle.ts
@@ -5,8 +5,8 @@ import { ArticleService } from '../api/connect/proto/article/v1/article_connectw
 import type { Article } from '../api/connect/proto/article/v1/article_pb';
 import { transport } from './transport';
 
-// 1画面に表示する記事の最大数
-const maxPageSize = 20;
+// 1画面に表示する記事の数
+const articlesPerPage = 20;
 
 // クライアント作成
 const client = createPromiseClient(ArticleService, transport);
@@ -25,7 +25,7 @@ export const useListArticles = () => {
     const key = `/api/v1/articles`;
 
     const request = {
-        maxPageSize,
+        articlesPerPage,
         pageToken: articlesState.currentIndex,
     };
 

--- a/frontend/src/swr/useApiArticle.ts
+++ b/frontend/src/swr/useApiArticle.ts
@@ -5,7 +5,7 @@ import { ArticleService } from '../api/connect/proto/article/v1/article_connectw
 import type { Article } from '../api/connect/proto/article/v1/article_pb';
 import { transport } from './transport';
 
-// 1画面に表示する記事の数
+// 1回に取得する記事の数
 const articlesPerPage = 20;
 
 // クライアント作成


### PR DESCRIPTION
記事一覧をread moreボタンで20個ずつ取得するよう修正しました。  
見た目はこんな感じ。

<img width="467" alt="Screenshot 2023-01-30 at 21 34 16" src="https://user-images.githubusercontent.com/38348784/215478386-896ef837-1fc1-417e-9194-236878a6f8cd.png">
